### PR TITLE
Add wiki_links package to mobile.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 lib
+node_modules/

--- a/.gitmodules
+++ b/.gitmodules
@@ -24,4 +24,4 @@
 	url = https://github.com/inkdropapp/inkdrop-embed.git
 [submodule "packages/wiki_links"]
 	path = packages/wiki_links
-	url = git@github.com:ryanpcmcquen/inkdrop_wiki_links.git
+	url = https://github.com/ryanpcmcquen/inkdrop_wiki_links.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "packages/embed"]
 	path = packages/embed
 	url = https://github.com/inkdropapp/inkdrop-embed.git
+[submodule "packages/wiki_links"]
+	path = packages/wiki_links
+	url = git@github.com:ryanpcmcquen/inkdrop_wiki_links.git

--- a/package-lock.json
+++ b/package-lock.json
@@ -13342,6 +13342,10 @@
         "string-width": "^4.0.0"
       }
     },
+    "wiki_links": {
+      "version": "file:packages/wiki_links",
+      "dev": true
+    },
     "window": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/window/-/window-4.2.6.tgz",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,12 @@
     "dev": "webpack --progress --config webpack.dev.config.babel.js --watch",
     "dev:server": "webpack-dev-server --progress --config webpack.dev.config.babel.js --port 8001 --host 0.0.0.0",
     "build": "npm run clean && npm run build:plugins && npm run build:index",
-    "build:plugins": "webpack --progress --config webpack.prod.config.babel.js && npm run build:index",
+    "build:plugins": "webpack --progress --config webpack.prod.config.babel.js",
     "build:index": "mkdir -p ./lib && babel-node ./tools/build-index.js",
     "clean": "rm -rf ./lib",
+    "winbuild": "npm run winclean && npm run build:plugins && npm run winbuild:index",
+    "winbuild:index": "babel-node tools/build-index.js",
+    "winclean": "rmdir /s /q lib",
     "lint": "eslint src",
     "prepublishOnly": "npm run build"
   },

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "toc": "file:packages/toc",
     "webpack": "^4.42.0",
     "webpack-cli": "^3.3.11",
-    "webpack-dev-server": "^3.10.3"
+    "webpack-dev-server": "^3.10.3",
+    "wiki_links": "file:packages/wiki_links"
   },
   "ava": {
     "require": [

--- a/test/index.js
+++ b/test/index.js
@@ -86,3 +86,14 @@ test.serial.cb('mermaid', t => {
   require('../lib/mermaid')
 })
 
+test.serial.cb('wiki_links', (t) => {
+  global.window.inkdrop.packages.setPackageMainModule = (name, p) => {
+    t.is(name, 'wiki_links')
+    t.is(p instanceof Object, true)
+    t.is(typeof p.activate, "function")
+    t.is(typeof p.deactivate, "function")
+    t.end()
+  }
+
+  require('../lib/wiki_links')
+})


### PR DESCRIPTION
Because of db limitations at the moment this only does a search for a `wiki_link`. But it is nicer than having nothing for someone who is using a lot of these!

![2020_12_25_1608884175__chrome_j8JWVjL0Ac](https://user-images.githubusercontent.com/772937/103127854-f7dcd800-4647-11eb-8403-e2c483200098.png)

Signed-off-by: Ryan McQuen <rpcm@linux.com>